### PR TITLE
Add support for iOS 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+
+.DS_Store

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "RxSwiftWidgets",
     platforms: [
-            .iOS(.v11),
+            .iOS(.v10),
         ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.

--- a/RxSwiftWidgets.xcodeproj/project.pbxproj
+++ b/RxSwiftWidgets.xcodeproj/project.pbxproj
@@ -2457,7 +2457,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/RxSwiftWidgetsDemo/Info.plist";
 				INFOPLIST_PREFIX_HEADER = "$(SRCROOT)/RxSwiftWidgetsDemo/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -2517,7 +2517,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/RxSwiftWidgetsDemo/Info.plist";
 				INFOPLIST_PREFIX_HEADER = "$(SRCROOT)/RxSwiftWidgetsDemo/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -2545,6 +2545,7 @@
 					"SWIFT_PACKAGE=1",
 					"DEBUG=1",
 				);
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_SWIFT_FLAGS = "$(inherited) -DXcode";
@@ -2632,6 +2633,7 @@
 					"$(inherited)",
 					"SWIFT_PACKAGE=1",
 				);
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_SWIFT_FLAGS = "$(inherited) -DXcode";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2850,7 +2852,7 @@
 					"$(SRCROOT)/.build/checkouts/RxSwift/Sources/RxCocoaRuntime/include",
 				);
 				INFOPLIST_FILE = RxSwiftWidgets.xcodeproj/RxSwiftWidgets_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_CFLAGS = "$(inherited)";
@@ -2881,7 +2883,7 @@
 					"$(SRCROOT)/.build/checkouts/RxSwift/Sources/RxCocoaRuntime/include",
 				);
 				INFOPLIST_FILE = RxSwiftWidgets.xcodeproj/RxSwiftWidgets_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_CFLAGS = "$(inherited)";
@@ -2943,7 +2945,7 @@
 					"$(SRCROOT)/.build/checkouts/RxSwift/Sources/RxCocoaRuntime/include",
 				);
 				INFOPLIST_FILE = RxSwiftWidgets.xcodeproj/RxSwiftWidgetsTests_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_CFLAGS = "$(inherited)";
@@ -2971,7 +2973,7 @@
 					"$(SRCROOT)/.build/checkouts/RxSwift/Sources/RxCocoaRuntime/include",
 				);
 				INFOPLIST_FILE = RxSwiftWidgets.xcodeproj/RxSwiftWidgetsTests_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_CFLAGS = "$(inherited)";

--- a/Sources/RxSwiftWidgets/Core/WidgetPositioning.swift
+++ b/Sources/RxSwiftWidgets/Core/WidgetPositioning.swift
@@ -106,56 +106,80 @@ extension Widgets.Position {
     }
 
     func anchorLeftEdge(of view: UIView, in superview: UIView, padding: CGFloat, safeArea: Bool) -> NSLayoutConstraint {
-        let superviewAnchor = safeArea ? superview.safeAreaLayoutGuide.leftAnchor : superview.leftAnchor
+        var superviewAnchor = superview.leftAnchor
+        if #available(iOS 11.0, *), safeArea {
+            superviewAnchor = superview.safeAreaLayoutGuide.leftAnchor
+        }
         let anchor = view.leftAnchor.constraint(equalTo: superviewAnchor, constant: padding)
         anchor.priority = .required
         return anchor
     }
 
     func limitLeftEdge(of view: UIView, in superview: UIView, padding: CGFloat, safeArea: Bool) -> NSLayoutConstraint {
-        let superviewAnchor = safeArea ? superview.safeAreaLayoutGuide.leftAnchor : superview.leftAnchor
+        var superviewAnchor = superview.leftAnchor
+        if #available(iOS 11.0, *), safeArea {
+            superviewAnchor = superview.safeAreaLayoutGuide.leftAnchor
+        }
         let anchor = view.leftAnchor.constraint(greaterThanOrEqualTo: superviewAnchor, constant: padding)
         anchor.priority = .defaultHigh
         return anchor
     }
 
     func anchorTopEdge(of view: UIView, in superview: UIView, padding: CGFloat, safeArea: Bool) -> NSLayoutConstraint {
-        let superviewAnchor = safeArea ? superview.safeAreaLayoutGuide.topAnchor : superview.topAnchor
+        var superviewAnchor = superview.topAnchor
+        if #available(iOS 11.0, *), safeArea {
+            superviewAnchor = superview.safeAreaLayoutGuide.topAnchor
+        }
         let anchor = view.topAnchor.constraint(equalTo: superviewAnchor, constant: padding)
         anchor.priority = .required
         return anchor
     }
 
     func limitTopEdge(of view: UIView, in superview: UIView, padding: CGFloat, safeArea: Bool) -> NSLayoutConstraint {
-        let superviewAnchor = safeArea ? superview.safeAreaLayoutGuide.topAnchor : superview.topAnchor
+        var superviewAnchor = superview.topAnchor
+        if #available(iOS 11.0, *), safeArea {
+            superviewAnchor = superview.safeAreaLayoutGuide.topAnchor
+        }
         let anchor = view.topAnchor.constraint(greaterThanOrEqualTo: superviewAnchor, constant: padding)
         anchor.priority = .defaultHigh
         return anchor
     }
 
     func anchorBottomEdge(of view: UIView, in superview: UIView, padding: CGFloat, safeArea: Bool) -> NSLayoutConstraint {
-        let superviewAnchor = safeArea ? superview.safeAreaLayoutGuide.bottomAnchor : superview.bottomAnchor
+        var superviewAnchor = superview.bottomAnchor
+        if #available(iOS 11.0, *), safeArea {
+            superviewAnchor = superview.safeAreaLayoutGuide.bottomAnchor
+        }
         let anchor = view.bottomAnchor.constraint(equalTo: superviewAnchor, constant: -padding)
         anchor.priority = .required
         return anchor
     }
 
     func limitBottomEdge(of view: UIView, in superview: UIView, padding: CGFloat, safeArea: Bool) -> NSLayoutConstraint {
-        let superviewAnchor = safeArea ? superview.safeAreaLayoutGuide.bottomAnchor : superview.bottomAnchor
+        var superviewAnchor = superview.bottomAnchor
+        if #available(iOS 11.0, *), safeArea {
+            superviewAnchor = superview.safeAreaLayoutGuide.bottomAnchor
+        }
         let anchor = view.bottomAnchor.constraint(lessThanOrEqualTo: superviewAnchor, constant: -padding)
         anchor.priority = .defaultHigh
         return anchor
     }
 
     func anchorRightEdge(of view: UIView, in superview: UIView, padding: CGFloat, safeArea: Bool) -> NSLayoutConstraint {
-        let superviewAnchor = safeArea ? superview.safeAreaLayoutGuide.rightAnchor : superview.rightAnchor
+        var superviewAnchor = superview.rightAnchor
+        if #available(iOS 11.0, *), safeArea {
+            superviewAnchor = superview.safeAreaLayoutGuide.rightAnchor
+        }
         let anchor = view.rightAnchor.constraint(equalTo: superviewAnchor, constant: -padding)
         anchor.priority = .required
         return anchor
     }
 
     func limitRightEdge(of view: UIView, in superview: UIView, padding: CGFloat, safeArea: Bool) -> NSLayoutConstraint {
-        let superviewAnchor = safeArea ? superview.safeAreaLayoutGuide.rightAnchor : superview.rightAnchor
+        var superviewAnchor = superview.rightAnchor
+        if #available(iOS 11.0, *), safeArea {
+            superviewAnchor = superview.safeAreaLayoutGuide.rightAnchor
+        }
         let anchor = view.rightAnchor.constraint(lessThanOrEqualTo: superviewAnchor, constant: -padding)
         anchor.priority = .defaultHigh
         return anchor

--- a/Sources/RxSwiftWidgets/Modifiers/WidgetModifyUINavigation.swift
+++ b/Sources/RxSwiftWidgets/Modifiers/WidgetModifyUINavigation.swift
@@ -12,14 +12,23 @@ import RxCocoa
 
 extension WidgetModifying {
 
+    public func navigationBar(title: String, hidden: Bool? = nil) -> Self {
+        _navigationBar(title: title, hidden: hidden)
+    }
+
+    @available(iOS 11.0, *)
     public func navigationBar(title: String, preferLargeTitles: Bool? = nil, hidden: Bool? = nil) -> Self {
-        return modified(WidgetModifierBlock<UIView> { _, context in
+        _navigationBar(title: title, preferLargeTitles: preferLargeTitles, hidden: hidden)
+    }
+
+    private func _navigationBar(title: String, preferLargeTitles: Bool? = nil, hidden: Bool? = nil) -> Self {
+        modified(WidgetModifierBlock<UIView> { _, context in
             if let vc = context.viewController {
                 vc.rx.methodInvoked(#selector(UIViewController.viewWillAppear(_:)))
                     .subscribe(onNext: { _ in
                         context.viewController?.title = title
                         guard let nav = context.navigator?.navigationController else { return }
-                        if let largeTitles = preferLargeTitles {
+                        if let largeTitles = preferLargeTitles, #available(iOS 11.0, *) {
                             nav.navigationBar.prefersLargeTitles = largeTitles
                         }
                         if let hidden = hidden {

--- a/Sources/RxSwiftWidgets/Widgets/Containers/HStackWidget.swift
+++ b/Sources/RxSwiftWidgets/Widgets/Containers/HStackWidget.swift
@@ -40,9 +40,13 @@ public struct HStackWidget
         let context = modifiers.modified(context, for: stack)
 
         stack.translatesAutoresizingMaskIntoConstraints = false
-        stack.insetsLayoutMarginsFromSafeArea = false
         stack.axis = .horizontal
-        stack.spacing = UIStackView.spacingUseSystem
+        if #available(iOS 11.0, *) {
+            stack.insetsLayoutMarginsFromSafeArea = false
+            stack.spacing = UIStackView.spacingUseSystem
+        } else {
+            stack.spacing = 0.0
+        }
 
         if let insets = modifiers.padding {
             stack.isLayoutMarginsRelativeArrangement = true

--- a/Sources/RxSwiftWidgets/Widgets/Containers/VStackWidget.swift
+++ b/Sources/RxSwiftWidgets/Widgets/Containers/VStackWidget.swift
@@ -40,9 +40,13 @@ public struct VStackWidget
         let context = modifiers.modified(context, for: stack)
 
         stack.translatesAutoresizingMaskIntoConstraints = false
-        stack.insetsLayoutMarginsFromSafeArea = false
         stack.axis = .vertical
-        stack.spacing = UIStackView.spacingUseSystem
+        if #available(iOS 11.0, *) {
+            stack.insetsLayoutMarginsFromSafeArea = false
+            stack.spacing = UIStackView.spacingUseSystem
+        } else {
+            stack.spacing = 0.0
+        }
 
         if let insets = modifiers.padding {
             stack.isLayoutMarginsRelativeArrangement = true

--- a/Sources/RxSwiftWidgets/Widgets/Containers/ZStackWidget.swift
+++ b/Sources/RxSwiftWidgets/Widgets/Containers/ZStackWidget.swift
@@ -31,8 +31,10 @@ public struct ZStackWidget
         let context = modifiers.modified(context, for: view)
 
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.insetsLayoutMarginsFromSafeArea = false
         view.backgroundColor = .clear
+        if #available(iOS 11.0, *) {
+            view.insetsLayoutMarginsFromSafeArea = false
+        }
 
         for widget in widgets {
             let subview = widget.build(with: context)

--- a/Sources/RxSwiftWidgets/Widgets/TableView/TableWidget.swift
+++ b/Sources/RxSwiftWidgets/Widgets/TableView/TableWidget.swift
@@ -87,7 +87,10 @@ open class TableWidget
         }
 
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.insetsLayoutMarginsFromSafeArea = false
+        if #available(iOS 11.0, *) {
+            view.insetsLayoutMarginsFromSafeArea = false
+        }
+        view.estimatedRowHeight = 44.0
         
         view.tableViewWidget = self
         view.dataSource = self


### PR DESCRIPTION
I'd like to bring in support for iOS 10 for this library. The project I work on will soon be dropping iOS 9 support, but we can't drop 10 for the foreseeable future. I've only just started with a legacy codebase full of MVC's (massive view controllers), and working on making views more compositional and code-based versus using xibs. Since SwiftUI is off the table, this looks to be a pretty sweet alternative



Something that needs a little work are the table cells, which go a little wonky with regards to the margins of the built-in cell types versus the custom cell. This also affects iOS 11